### PR TITLE
Rename vendor to jan-made, update dependabot and PHP support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "composer" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "composer"
+    directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: "increase"
+    reviewers:
+      - "trejjam"
+    labels:
+      - "automerge"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "trejjam"
+    labels:
+      - "automerge"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "trejjam/configuration",
+	"name": "jan-made/configuration",
 	"description": "Nette base configuration object",
 	"keywords": [
 		"nette",
@@ -12,10 +12,13 @@
 		}
 	],
 	"support": {
-		"issues": "https://github.com/trejjam/configuration/issues"
+		"issues": "https://github.com/jan-made/configuration/issues"
+	},
+	"replace": {
+		"trejjam/configuration": "self.version"
 	},
 	"require": {
-		"php": "^8.1 | ^8.2",
+		"php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
 
 		"nette/di": "^3.1",
 		"nette/php-generator": "^4.0"


### PR DESCRIPTION
## Summary
- Rename composer package from `trejjam/configuration` to `jan-made/configuration`
- Add `replace` for old package name to support transparent migration
- Update PHP support to `^8.2 || ^8.3 || ^8.4 || ^8.5`
- Clean up dependabot config: add `versioning-strategy: increase`, reviewers, labels, and github-actions ecosystem