### PR TITLE
🔖 chore: update branch alias to v0.3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "v0.2.x-dev"
+			"dev-master": "v0.3.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Update composer branch alias from `v0.2.x-dev` to `v0.3.x-dev` after v0.2.0 release